### PR TITLE
fix: safeguard non-skyblock items

### DIFF
--- a/src/main/kotlin/me/owdding/iconographic/features/tags/CategoryTags.kt
+++ b/src/main/kotlin/me/owdding/iconographic/features/tags/CategoryTags.kt
@@ -19,6 +19,8 @@ data object CategoryTags : TooltipFeature() {
 
     private val idRegex = Regex("(?i)^(?<name>.+?)\\s*\\(\\s*ID\\s+(?<id>[A-Z0-9]+)\\s*\\)$")
 
+    override fun ItemStack.applies(): Boolean = (DataTypes.SKYBLOCK_ID() != null)
+
     override fun ItemStack.leftTags(): List<TooltipTag> {
         if (DataTypes.SKYBLOCK_ID()?.isEnchantment == true) {
             return listOf(TooltipTag.literal("ENCHANTED BOOK", 0xFF66FF))

--- a/src/main/kotlin/me/owdding/iconographic/features/tags/RarityTag.kt
+++ b/src/main/kotlin/me/owdding/iconographic/features/tags/RarityTag.kt
@@ -26,6 +26,8 @@ data object RarityTag : TooltipFeature() {
     override val enabled: Boolean get() = TagConfig.rarity
     override val priority: Int = 10
 
+    override fun ItemStack.applies(): Boolean = (DataTypes.SKYBLOCK_ID() != null)
+
     override fun ItemStack.leftTags(): List<TooltipTag> {
         val rarity = DataTypes.RARITY() ?: return emptyList()
 


### PR DESCRIPTION
Closes #49 