### PR TITLE
feat: no rarity custom color

### DIFF
--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -64,6 +64,14 @@
           "hide": "Hide Extra Stats",
           "side": "Side Gui",
           "side_shift": "Side Gui when holding Shift"
+        },
+        "replaceNoRarityColor": {
+          "@value": "Replace No Rarity Tooltip Color",
+          "desc": "Enables the replacing of the default color used on tooltips for items without a Skyblock rarity."
+        },
+        "customNoRarityColor": {
+          "@value": "No Rarity Tooltip Color",
+          "desc": "The color to use for replacing if Replace No Rarity Tooltip Color is enabled."
         }
       },
       "tags": {

--- a/src/main/kotlin/me/owdding/iconographic/CustomTooltipComponent.kt
+++ b/src/main/kotlin/me/owdding/iconographic/CustomTooltipComponent.kt
@@ -52,7 +52,7 @@ data class Tooltip(
     val leftTags: List<TooltipTag>,
     val rightTags: List<TooltipTag>,
     val topRightIcon: Identifier?,
-    val rarity: SkyBlockRarity,
+    val rarity: SkyBlockRarity?,
     val isRarityUpgraded: Boolean,
     val entries: List<TooltipLine>,
 )

--- a/src/main/kotlin/me/owdding/iconographic/Iconographic.kt
+++ b/src/main/kotlin/me/owdding/iconographic/Iconographic.kt
@@ -13,6 +13,7 @@ import me.owdding.iconographic.generated.IconographicTooltipFeatures
 import me.owdding.iconographic.render.TooltipHeader
 import me.owdding.iconographic.system.CustomTooltip
 import me.owdding.iconographic.system.IconographicTooltipComponent
+import me.owdding.iconographic.utils.ColorUtils
 import me.owdding.iconographic.utils.chat.DisplayColor.displayColor
 import me.owdding.iconographic.utils.chat.sendWithPrefix
 import me.owdding.iconographic.utils.debug.DebugBuilder
@@ -128,9 +129,7 @@ object Iconographic : ClientModInitializer, MeowddingLogger by MeowddingLogger.a
         val tooltipInfo = lines.toInformation()
         val tooltip = CustomTooltip.update(item, tooltipInfo)
 
-        currentTooltipRarityColor = tooltip.rarity?.displayColor
-            ?: if (VisualsConfig.replaceNoRarityColor) VisualsConfig.customNoRarityColor
-            else SkyBlockRarity.COMMON.displayColor
+        currentTooltipRarityColor = ColorUtils.getColorFromRarity(tooltip.rarity)
 
         val entries = tooltip.entries.toMutableList()
         entries.addFirst(TooltipHeader(tooltip))

--- a/src/main/kotlin/me/owdding/iconographic/Iconographic.kt
+++ b/src/main/kotlin/me/owdding/iconographic/Iconographic.kt
@@ -5,6 +5,7 @@ import com.teamresourceful.resourcefulconfig.api.loader.Configurator
 import me.owdding.iconographic.TooltipInformation.Companion.toInformation
 import me.owdding.iconographic.api.ImcHandler
 import me.owdding.iconographic.config.Config
+import me.owdding.iconographic.config.categories.visuals.VisualsConfig
 import me.owdding.iconographic.generated.BuildInfo
 import me.owdding.iconographic.generated.IconographicApiDebug
 import me.owdding.iconographic.generated.IconographicModules
@@ -30,6 +31,7 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.resources.Identifier
 import net.minecraft.world.item.ItemStack
 import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
+import tech.thatgravyboat.skyblockapi.api.data.SkyBlockRarity
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
 import tech.thatgravyboat.skyblockapi.helpers.McClient
 import tech.thatgravyboat.skyblockapi.platform.Identifiers
@@ -126,7 +128,9 @@ object Iconographic : ClientModInitializer, MeowddingLogger by MeowddingLogger.a
         val tooltipInfo = lines.toInformation()
         val tooltip = CustomTooltip.update(item, tooltipInfo)
 
-        currentTooltipRarityColor = tooltip.rarity.displayColor
+        currentTooltipRarityColor = tooltip.rarity?.displayColor
+            ?: if (VisualsConfig.replaceNoRarityColor) VisualsConfig.customNoRarityColor
+            else SkyBlockRarity.COMMON.displayColor
 
         val entries = tooltip.entries.toMutableList()
         entries.addFirst(TooltipHeader(tooltip))

--- a/src/main/kotlin/me/owdding/iconographic/config/categories/visuals/VisualsConfig.kt
+++ b/src/main/kotlin/me/owdding/iconographic/config/categories/visuals/VisualsConfig.kt
@@ -14,6 +14,8 @@ object VisualsConfig : CategoryKt("visuals"), AutoTranslated {
     val vanillaBackground by autoBoolean(true)
     val forceDefaultVanillaBackground by autoBoolean(false)
     val skyBlockColor by autoBoolean(true)
+    val replaceNoRarityColor by autoBoolean(false)
+    val customNoRarityColor by autoColor(0xFFFFFF)
 
     init { autoSeparator("text_formatting") }
     val shinyHolographic by autoBoolean(true)

--- a/src/main/kotlin/me/owdding/iconographic/render/TooltipHeader.kt
+++ b/src/main/kotlin/me/owdding/iconographic/render/TooltipHeader.kt
@@ -8,6 +8,7 @@ import me.owdding.iconographic.config.NonSkyBlockItemMode
 import me.owdding.iconographic.config.categories.visuals.VisualsConfig
 import me.owdding.iconographic.font
 import me.owdding.iconographic.system.TooltipTag
+import me.owdding.iconographic.utils.ColorUtils
 import me.owdding.iconographic.utils.chat.DisplayColor.displayColor
 import net.minecraft.client.gui.Font
 import net.minecraft.client.gui.GuiGraphicsExtractor
@@ -59,11 +60,7 @@ data class TooltipHeader(
                 y - 1,
                 24,
                 24,
-                ARGB.opaque(
-                    rarity?.displayColor
-                        ?: if (VisualsConfig.replaceNoRarityColor) VisualsConfig.customNoRarityColor
-                        else SkyBlockRarity.COMMON.displayColor
-                )
+                ARGB.opaque(ColorUtils.getColorFromRarity(rarity))
             )
             graphics.extractItem(item, x + 3, y + 3)
         }

--- a/src/main/kotlin/me/owdding/iconographic/render/TooltipHeader.kt
+++ b/src/main/kotlin/me/owdding/iconographic/render/TooltipHeader.kt
@@ -34,7 +34,7 @@ data class TooltipHeader(
     val leftTags: List<TooltipTag>,
     val rightTags: List<TooltipTag>,
     val icon: Identifier?,
-    val rarity: SkyBlockRarity
+    val rarity: SkyBlockRarity?
 ) : ExtractableTooltipLine {
 
     constructor(tooltip: Tooltip) : this(tooltip.item, tooltip.name, tooltip.leftTags, tooltip.rightTags, tooltip.topRightIcon, tooltip.rarity)
@@ -59,7 +59,11 @@ data class TooltipHeader(
                 y - 1,
                 24,
                 24,
-                ARGB.opaque(rarity.displayColor)
+                ARGB.opaque(
+                    rarity?.displayColor
+                        ?: if (VisualsConfig.replaceNoRarityColor) VisualsConfig.customNoRarityColor
+                        else SkyBlockRarity.COMMON.displayColor
+                )
             )
             graphics.extractItem(item, x + 3, y + 3)
         }

--- a/src/main/kotlin/me/owdding/iconographic/system/CustomTooltip.kt
+++ b/src/main/kotlin/me/owdding/iconographic/system/CustomTooltip.kt
@@ -70,7 +70,7 @@ object CustomTooltip {
                 update()
             }
         }
-        val rarity = modifiedItem[DataTypes.RARITY] ?: SkyBlockRarity.COMMON
+        val rarity = modifiedItem[DataTypes.RARITY]
 
         return Tooltip(
             item = modifiedItem,

--- a/src/main/kotlin/me/owdding/iconographic/utils/Utils.kt
+++ b/src/main/kotlin/me/owdding/iconographic/utils/Utils.kt
@@ -3,6 +3,8 @@ package me.owdding.iconographic.utils
 import me.owdding.iconographic.ComponentLike
 import me.owdding.iconographic.TooltipLine
 import me.owdding.iconographic.TooltipLine.Companion.asComponentOrNull
+import me.owdding.iconographic.config.categories.visuals.VisualsConfig
+import me.owdding.iconographic.utils.chat.DisplayColor.displayColor
 import net.minecraft.network.chat.CommonComponents
 import net.minecraft.network.chat.Component
 import tech.thatgravyboat.skyblockapi.api.data.SkyBlockRarity
@@ -184,3 +186,10 @@ open class ListMerger<T>(open val original: List<T>, open var index: Int = 0) {
     }
 }
 
+object ColorUtils {
+    fun getColorFromRarity(rarity: SkyBlockRarity?): Int {
+        return rarity?.displayColor
+            ?: if (VisualsConfig.replaceNoRarityColor) VisualsConfig.customNoRarityColor
+            else SkyBlockRarity.COMMON.displayColor
+    }
+}


### PR DESCRIPTION
Adds support for replacing the color of tooltips used on items without a Skyblock rarity.
Closes #7 