### PR TITLE
fix: switch itemAbility to false by default

### DIFF
--- a/src/main/kotlin/me/owdding/iconographic/config/categories/misc/MiscConfig.kt
+++ b/src/main/kotlin/me/owdding/iconographic/config/categories/misc/MiscConfig.kt
@@ -9,7 +9,7 @@ object MiscConfig : CategoryKt("misc"), AutoTranslated {
     override val name: TranslatableValue = Translated(translationBase)
 
     init { autoSeparator("misc") }
-    val itemAbility by autoBoolean(true)
+    val itemAbility by autoBoolean(false)
     val enchantedBookNames by autoBoolean(true)
     val skillLevelBar by autoBoolean(true)
 }


### PR DESCRIPTION
Sets itemAbility inside MiscConfig to false by default. Resolves problems related to users finding the ability line uncomfortable to read on tooltips that are too wide.
Closes #28 